### PR TITLE
Update ng-croppie.js

### DIFF
--- a/unminified/ng-croppie.js
+++ b/unminified/ng-croppie.js
@@ -79,8 +79,8 @@ angular.module('ngCroppie', []).directive('ngCroppie', [
                 // create new croppie and settime for updates
                 var c = new Croppie(elem[0], options);
                 // get Croppie elements for further calculations
-                var croppieBody = angular.element(document.getElementsByTagName('ng-croppie'))[0];
-                var croppieCanvas = angular.element(document.getElementsByClassName('cr-boundary'))[0];
+                var croppieBody = angular.element(elem[0])[0];
+                var croppieCanvas = angular.element(elem[0].getElementsByClassName('cr-boundary'))[0];
 
                 var intervalID;
 


### PR DESCRIPTION
Changed line 82 and 83.

document.getElementByIdTag and document.getElementByClassName does not work with angular-ui modals. The link function seems to execute before modal DOM is loaded. Since croppieBody is just elem[0] and croppieCanvas is inside elem[0], this change solved the problem.